### PR TITLE
feat(Admin): add settings page

### DIFF
--- a/apps/server/prisma/migrations/20230127082110_invites_added/migration.sql
+++ b/apps/server/prisma/migrations/20230127082110_invites_added/migration.sql
@@ -1,0 +1,5 @@
+-- CreateTable
+CREATE TABLE "Invites" (
+    "invite" TEXT NOT NULL PRIMARY KEY,
+    "Date" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -37,6 +37,11 @@ model SignupDomain {
   @@map("signup_domain")
 }
 
+model Invites {
+  invite String   @id
+  Date   DateTime @default(now())
+}
+
 model Auditlog {
   id   String   @id @unique @default(uuid())
   date DateTime @default(now())

--- a/apps/server/src/api/admin/domains.ts
+++ b/apps/server/src/api/admin/domains.ts
@@ -5,18 +5,36 @@ import { Utils } from "../../lib/utils.js";
 import type Server from "../../Server.js";
 
 export default async function handler(server: Server, req: Request, res: Response) {
-	const { page: _page } = req.query;
-	const page = isNaN(Number(_page)) ? 0 : Number(_page);
+	if (req.method === "GET") {
+		const { page: _page } = req.query;
+		const page = isNaN(Number(_page)) ? 0 : Number(_page);
 
-	const domains = await server.prisma.signupDomain.findMany();
-	const chunks = Utils.chunk(domains, 50);
-	const chunk = page > chunks.length ? chunks[chunks.length - 1] : chunks[page];
+		const domains = await server.prisma.signupDomain.findMany();
+		const chunks = Utils.chunk(domains, 50);
+		const chunk = page > chunks.length ? chunks[chunks.length - 1] : chunks[page];
 
-	res.send({
-		entries: chunk ?? [],
-		pages: chunks.length
-	});
+		res.send({
+			entries: chunk ?? [],
+			pages: chunks.length
+		});
+
+		return;
+	}
+
+	const { domain } = req.body;
+	if (typeof domain !== "string") {
+		res.status(400).send({ message: "Invalid domain provided" });
+		return;
+	}
+
+	if (domain.startsWith(".") || domain.endsWith(".") || domain.startsWith("-")) {
+		res.status(400).send({ message: "Invalid domain provided" });
+		return;
+	}
+
+	await server.prisma.signupDomain.create({ data: { domain } });
+	res.sendStatus(204);
 }
 
-export const methods: RequestMethods[] = ["get"];
+export const methods: RequestMethods[] = ["get", "post"];
 export const middleware: Middleware[] = [Auth.adminMiddleware.bind(Auth)];

--- a/apps/server/src/api/admin/domains.ts
+++ b/apps/server/src/api/admin/domains.ts
@@ -33,6 +33,7 @@ export default async function handler(server: Server, req: Request, res: Respons
 			return;
 		}
 
+		server.adminAuditLogs.register("SignUp Domain Create", `Domain: ${domain}`);
 		await server.prisma.signupDomain.create({ data: { domain } });
 		res.sendStatus(204);
 		return;
@@ -45,6 +46,7 @@ export default async function handler(server: Server, req: Request, res: Respons
 			return;
 		}
 
+		server.adminAuditLogs.register("SignUp Domains Delete", `Domains: ${domains.join(",")}`);
 		await server.prisma.signupDomain.deleteMany({ where: { domain: { in: domains } } });
 		res.sendStatus(204);
 	}

--- a/apps/server/src/api/admin/domains.ts
+++ b/apps/server/src/api/admin/domains.ts
@@ -1,0 +1,22 @@
+import type { Response, Request } from "express";
+import { Auth } from "../../lib/Auth.js";
+import type { Middleware, RequestMethods } from "../../lib/types.js";
+import { Utils } from "../../lib/utils.js";
+import type Server from "../../Server.js";
+
+export default async function handler(server: Server, req: Request, res: Response) {
+	const { page: _page } = req.query;
+	const page = isNaN(Number(_page)) ? 0 : Number(_page);
+
+	const domains = await server.prisma.signupDomain.findMany();
+	const chunks = Utils.chunk(domains, 50);
+	const chunk = page > chunks.length ? chunks[chunks.length - 1] : chunks[page];
+
+	res.send({
+		entries: chunk ?? [],
+		pages: chunks.length
+	});
+}
+
+export const methods: RequestMethods[] = ["get"];
+export const middleware: Middleware[] = [Auth.adminMiddleware.bind(Auth)];

--- a/apps/server/src/api/admin/settings.ts
+++ b/apps/server/src/api/admin/settings.ts
@@ -1,0 +1,82 @@
+import type { Response, Request } from "express";
+import { Auth } from "../../lib/Auth.js";
+import type { Middleware, RequestMethods } from "../../lib/types.js";
+import type Server from "../../Server.js";
+
+export default async function handler(server: Server, req: Request, res: Response) {
+	const domains = await server.prisma.signupDomain.findMany();
+
+	if (req.method === "GET") {
+		res.send({
+			defaults: {
+				authMode: server.envConfig.authMode,
+				signUpMode: server.envConfig.signUpMode,
+				extensions: server.envConfig.extensionsList,
+				extensionsMode: server.envConfig.extensionsMode,
+				maxStorage: server.envConfig.maxStorage,
+				maxUploadSize: server.envConfig.maxUpload,
+				auditlog: server.envConfig.auditLogDuration
+			},
+			domains
+		});
+
+		return;
+	}
+
+	if (req.method === "POST") {
+		try {
+			// const data = req.body as Required<CreateUserFormBody>;
+			// if (!data.domain || !domains.map((domain) => domain.domain).includes(data.domain)) {
+			// 	res.status(400).send({ message: "Invalid sign-up domain provided" });
+			// 	return;
+			// }
+
+			// const DOMAIN_REGEX = /[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?/g;
+			// const extensionRes = (data.extension ?? "").match(DOMAIN_REGEX) ?? [];
+			// data.extension = extensionRes[0] ?? "";
+
+			// if (data.domain.startsWith("*.") && !data.extension.length) {
+			// 	res.status(400).send({ message: "Invalid sign-up subdomain provided" });
+			// 	return;
+			// }
+
+			// if (!["block", "pass"].includes(data.extensionsMode)) {
+			// 	res.status(400).send({ message: "Invalid extensionMode provided" });
+			// 	return;
+			// }
+
+			// const auditlog = ms(data.auditlog);
+			// if (isNaN(auditlog)) {
+			// 	res.status(400).send({ message: "Invalid auditlog duration provided" });
+			// 	return;
+			// }
+
+			// data.extensions = data.extensions.filter((ext) => ext.startsWith(".") && !ext.endsWith("."));
+			// const domain = data.domain.startsWith("*.") ? `` : data.domain;
+
+			// await server.domains.create({
+			// 	disabled: false,
+			// 	domain,
+			// 	extensionsList: data.extensions.join(","),
+			// 	extensionsMode: data.extensionsMode,
+			// 	maxStorage: data.storage,
+			// 	maxUploadSize: data.uploadSize,
+			// 	auditlogDuration: data.auditlog
+			// });
+
+			// if (!data.domain.startsWith("*.")) {
+			// 	await server.prisma.signupDomain.delete({ where: { domain: data.domain } });
+			// }
+
+			// server.adminAuditLogs.register("Create User", `User: ${data.domain} (${server.domains.get(data.domain)!.filesPath})`);
+			res.sendStatus(204);
+			return;
+		} catch (err) {
+			server.logger.fatal(`[CREATE:POST]: Fatal error while creating a new PaperPlane account `, err);
+			res.status(500).send({ message: "Internal server error occured, please try again later." });
+		}
+	}
+}
+
+export const methods: RequestMethods[] = ["get", "post"];
+export const middleware: Middleware[] = [Auth.adminMiddleware.bind(Auth)];

--- a/apps/server/src/api/auth/login.ts
+++ b/apps/server/src/api/auth/login.ts
@@ -19,12 +19,8 @@ export default function handler(server: Server, req: Request, res: Response) {
 		return;
 	}
 
-	const authSecret = domain!.secret;
-	if (!authSecret.length) {
-		if (typeof code === "string" && code.startsWith("BC-")) {
-			// TODO: use back-up code
-		}
-
+	if (typeof code === "string" && code.startsWith("BC-")) {
+		// TODO: use back-up code
 		res.status(400).send({ message: "Invalid account provided" });
 		return;
 	}

--- a/apps/server/src/api/invites/create.ts
+++ b/apps/server/src/api/invites/create.ts
@@ -18,7 +18,9 @@ export default async function handler(server: Server, req: Request, res: Respons
 	}
 
 	const invites: string[] = _invites.filter((inv) => typeof inv === "string");
-	await Promise.all(invites.map((inv) => server.domains.deleteInvite(inv)));
+	for await (const invite of invites) {
+		await server.domains.deleteInvite(invite);
+	}
 
 	res.sendStatus(204);
 }

--- a/apps/server/src/api/invites/create.ts
+++ b/apps/server/src/api/invites/create.ts
@@ -1,0 +1,13 @@
+import type { Response, Request } from "express";
+import { Auth } from "../../lib/Auth.js";
+import type { Middleware, RequestMethods } from "../../lib/types.js";
+import type Server from "../../Server.js";
+
+export default async function handler(server: Server, req: Request, res: Response) {
+	const invite = await server.domains.createInvite();
+
+	res.send(invite);
+}
+
+export const methods: RequestMethods[] = ["post"];
+export const middleware: Middleware[] = [Auth.adminMiddleware.bind(Auth)];

--- a/apps/server/src/api/invites/create.ts
+++ b/apps/server/src/api/invites/create.ts
@@ -4,10 +4,24 @@ import type { Middleware, RequestMethods } from "../../lib/types.js";
 import type Server from "../../Server.js";
 
 export default async function handler(server: Server, req: Request, res: Response) {
-	const invite = await server.domains.createInvite();
+	if (req.method === "POST") {
+		const invite = await server.domains.createInvite();
+		res.send(invite);
 
-	res.send(invite);
+		return;
+	}
+
+	const { invites: _invites } = req.body;
+	if (!Array.isArray(_invites)) {
+		res.status(400).send({ message: "Incorrect invite provided" });
+		return;
+	}
+
+	const invites: string[] = _invites.filter((inv) => typeof inv === "string");
+	await Promise.all(invites.map((inv) => server.domains.deleteInvite(inv)));
+
+	res.sendStatus(204);
 }
 
-export const methods: RequestMethods[] = ["post"];
+export const methods: RequestMethods[] = ["post", "delete"];
 export const middleware: Middleware[] = [Auth.adminMiddleware.bind(Auth)];

--- a/apps/server/src/api/invites/list.ts
+++ b/apps/server/src/api/invites/list.ts
@@ -1,0 +1,22 @@
+import type { Response, Request } from "express";
+import { Auth } from "../../lib/Auth.js";
+import type { Middleware, RequestMethods } from "../../lib/types.js";
+import { Utils } from "../../lib/utils.js";
+import type Server from "../../Server.js";
+
+export default function handler(server: Server, req: Request, res: Response) {
+	const { page: _page } = req.query;
+	const page = isNaN(Number(_page)) ? 0 : Number(_page);
+
+	const { invites } = server.domains;
+	const chunks = Utils.chunk(invites, 50);
+	const chunk = page > chunks.length ? chunks[chunks.length - 1] : chunks[page];
+
+	res.send({
+		entries: chunk,
+		pages: chunks.length
+	});
+}
+
+export const methods: RequestMethods[] = ["get"];
+export const middleware: Middleware[] = [Auth.adminMiddleware.bind(Auth)];

--- a/apps/server/src/api/invites/list.ts
+++ b/apps/server/src/api/invites/list.ts
@@ -13,7 +13,7 @@ export default function handler(server: Server, req: Request, res: Response) {
 	const chunk = page > chunks.length ? chunks[chunks.length - 1] : chunks[page];
 
 	res.send({
-		entries: chunk,
+		entries: chunk ?? [],
 		pages: chunks.length
 	});
 }

--- a/apps/server/src/lib/Auth.ts
+++ b/apps/server/src/lib/Auth.ts
@@ -39,11 +39,15 @@ export class Auth {
 	}
 
 	public static verifyJWTToken(token: string, secret: string, expected: string): boolean {
-		const res = Jwt.verify(token, secret);
-		if (typeof res !== "object") return false;
+		try {
+			const res = Jwt.verify(token, secret);
+			if (typeof res !== "object") return false;
 
-		const version = process.env.NODE_ENV === "development" ? "paperplane_dev" : "paperplane_stable";
-		return res.version === version && res.account === expected;
+			const version = process.env.NODE_ENV === "development" ? "paperplane_dev" : "paperplane_stable";
+			return res.version === version && res.account === expected;
+		} catch (error) {
+			return false;
+		}
 	}
 
 	public static encryptToken(token: string, secret: string) {

--- a/apps/server/src/lib/Config.ts
+++ b/apps/server/src/lib/Config.ts
@@ -69,6 +69,21 @@ export class Config {
 		await this.triggerUpdate();
 	}
 
+	public async update(config: Partial<Omit<EnvConfig, "encryptionKey" | "internalApiKey" | "admin2FASecret" | "PORT" | "INSECURE_REQUESTS">>) {
+		this.config = {
+			...this.config,
+			maxStorage: this.parseConfigItem(config.maxStorage?.toString() || "MAX_STORAGE"),
+			maxUpload: this.parseConfigItem(config.maxUpload?.toString() || "MAX_UPLOAD_SIZE"),
+			auditLogDuration: this.parseConfigItem(config.auditLogDuration?.toString() || "AUDIT_LOG_DURATION"),
+			authMode: this.parseConfigItem(config.authMode || "AUTH_MODE"),
+			signUpMode: this.parseConfigItem(config.signUpMode || "SIGNUP_MODE"),
+			extensionsList: this.parseConfigItem(config.extensionsList?.join(",") || "EXTENSIONS_LIST"),
+			extensionsMode: this.parseConfigItem(config.extensionsMode || "EXTENSIONS_MODE")
+		};
+
+		await this.triggerUpdate();
+	}
+
 	public parseStorage(storage: string): number;
 	public parseStorage(storage: number): string;
 	public parseStorage(storage: string | number): number | string {
@@ -99,8 +114,12 @@ export class Config {
 		return `${storage.toFixed(1)} ${units[num]}`;
 	}
 
+	private parseConfigItem(value: string): any;
 	private parseConfigItem(key: keyof RawEnvConfig): any {
-		const value = process.env[key];
+		let value: string | undefined;
+
+		if (Boolean(process.env[key])) value = process.env[key];
+		else value = key;
 
 		switch (key) {
 			case "ENCRYPTION_KEY":

--- a/apps/server/src/lib/Config.ts
+++ b/apps/server/src/lib/Config.ts
@@ -72,13 +72,13 @@ export class Config {
 	public async update(config: Partial<Omit<EnvConfig, "encryptionKey" | "internalApiKey" | "admin2FASecret" | "PORT" | "INSECURE_REQUESTS">>) {
 		this.config = {
 			...this.config,
-			maxStorage: this.parseConfigItem(config.maxStorage?.toString() || "MAX_STORAGE"),
-			maxUpload: this.parseConfigItem(config.maxUpload?.toString() || "MAX_UPLOAD_SIZE"),
-			auditLogDuration: this.parseConfigItem(config.auditLogDuration?.toString() || "AUDIT_LOG_DURATION"),
-			authMode: this.parseConfigItem(config.authMode || "AUTH_MODE"),
-			signUpMode: this.parseConfigItem(config.signUpMode || "SIGNUP_MODE"),
-			extensionsList: this.parseConfigItem(config.extensionsList?.join(",") || "EXTENSIONS_LIST"),
-			extensionsMode: this.parseConfigItem(config.extensionsMode || "EXTENSIONS_MODE")
+			maxStorage: this.parseConfigItem("MAX_STORAGE", config.maxStorage?.toString()),
+			maxUpload: this.parseConfigItem("MAX_UPLOAD_SIZE", config.maxUpload?.toString()),
+			auditLogDuration: this.parseConfigItem("AUDIT_LOG_DURATION", config.auditLogDuration?.toString()),
+			authMode: this.parseConfigItem("AUTH_MODE", config.authMode),
+			signUpMode: this.parseConfigItem("SIGNUP_MODE", config.signUpMode),
+			extensionsList: this.parseConfigItem("EXTENSIONS_LIST", config.extensionsList?.join(",")),
+			extensionsMode: this.parseConfigItem("EXTENSIONS_MODE", config.extensionsMode)
 		};
 
 		await this.triggerUpdate();
@@ -114,12 +114,8 @@ export class Config {
 		return `${storage.toFixed(1)} ${units[num]}`;
 	}
 
-	private parseConfigItem(value: string): any;
-	private parseConfigItem(key: keyof RawEnvConfig): any {
-		let value: string | undefined;
-
-		if (Boolean(process.env[key])) value = process.env[key];
-		else value = key;
+	private parseConfigItem(key: keyof RawEnvConfig, value?: string): any {
+		if (!value) value = process.env[key];
 
 		switch (key) {
 			case "ENCRYPTION_KEY":

--- a/apps/server/src/lib/Domains/Domain.ts
+++ b/apps/server/src/lib/Domains/Domain.ts
@@ -30,6 +30,15 @@ export class Domain {
 		this.recordStorage();
 	}
 
+	public async resetAuth() {
+		const res = await this.server.prisma.domain.update({
+			where: { domain: this.domain },
+			data: { password: null, twoFactorSecret: null, backupCodes: "paperplane-cdn" }
+		});
+
+		this._parse(res);
+	}
+
 	public async update(data: Prisma.DomainUpdateArgs["data"]) {
 		const res = await this.server.prisma.domain.update({ where: { domain: this.domain }, data });
 		this._parse(res);

--- a/apps/server/src/lib/Domains/Domains.ts
+++ b/apps/server/src/lib/Domains/Domains.ts
@@ -28,12 +28,16 @@ export class Domains {
 		if (found) {
 			this.invites = this.invites.filter((inv) => inv.invite !== found.invite);
 			await this.server.prisma.invites.delete({ where: { invite: found.invite } });
+
+			this.server.adminAuditLogs.register("Invite Delete", `Invite: ${found.invite}`);
 		}
 	}
 
 	public async createInvite() {
 		const invite = await this.server.prisma.invites.create({ data: { invite: Auth.generateToken(16) } });
 		this.invites.push(invite);
+
+		this.server.adminAuditLogs.register("Invite Create", `Invite: ${invite.invite}`);
 
 		return invite;
 	}

--- a/apps/server/src/lib/Domains/Domains.ts
+++ b/apps/server/src/lib/Domains/Domains.ts
@@ -4,9 +4,11 @@ import { Domain } from "./Domain.js";
 import type Prisma from "@prisma/client";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import type { Invites } from "@prisma/client";
 
 export class Domains {
 	public domains = new Collection<string, Domain>();
+	public invites: Invites[] = [];
 
 	public constructor(public server: Server) {}
 
@@ -16,6 +18,8 @@ export class Domains {
 			const dm = new Domain(this.server, domain);
 			this.domains.set(dm.domain, dm);
 		}
+
+		this.invites = await this.server.prisma.invites.findMany();
 	}
 
 	public async resetAuth() {

--- a/apps/server/src/lib/Domains/Domains.ts
+++ b/apps/server/src/lib/Domains/Domains.ts
@@ -23,6 +23,14 @@ export class Domains {
 		this.invites = await this.server.prisma.invites.findMany();
 	}
 
+	public async deleteInvite(invite: string) {
+		const found = this.invites.find((inv) => inv.invite === invite);
+		if (found) {
+			this.invites = this.invites.filter((inv) => inv.invite !== found.invite);
+			await this.server.prisma.invites.delete({ where: { invite: found.invite } });
+		}
+	}
+
 	public async createInvite() {
 		const invite = await this.server.prisma.invites.create({ data: { invite: Auth.generateToken(16) } });
 		this.invites.push(invite);

--- a/apps/server/src/lib/Domains/Domains.ts
+++ b/apps/server/src/lib/Domains/Domains.ts
@@ -5,6 +5,7 @@ import type Prisma from "@prisma/client";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { Invites } from "@prisma/client";
+import { Auth } from "../Auth.js";
 
 export class Domains {
 	public domains = new Collection<string, Domain>();
@@ -20,6 +21,13 @@ export class Domains {
 		}
 
 		this.invites = await this.server.prisma.invites.findMany();
+	}
+
+	public async createInvite() {
+		const invite = await this.server.prisma.invites.create({ data: { invite: Auth.generateToken(16) } });
+		this.invites.push(invite);
+
+		return invite;
 	}
 
 	public async resetAuth() {

--- a/apps/server/src/lib/Domains/Domains.ts
+++ b/apps/server/src/lib/Domains/Domains.ts
@@ -18,6 +18,12 @@ export class Domains {
 		}
 	}
 
+	public async resetAuth() {
+		for await (const [, domain] of this.domains) {
+			await domain.resetAuth();
+		}
+	}
+
 	public async create(data: Prisma.Prisma.DomainCreateArgs["data"]) {
 		const res = await this.server.prisma.domain.create({ data });
 

--- a/apps/server/src/lib/Domains/Domains.ts
+++ b/apps/server/src/lib/Domains/Domains.ts
@@ -22,6 +22,8 @@ export class Domains {
 		for await (const [, domain] of this.domains) {
 			await domain.resetAuth();
 		}
+
+		this.server.adminAuditLogs.register("AuthMode Change", `Mode: ${this.server.envConfig.authMode}`);
 	}
 
 	public async create(data: Prisma.Prisma.DomainCreateArgs["data"]) {

--- a/apps/server/src/lib/types.ts
+++ b/apps/server/src/lib/types.ts
@@ -118,3 +118,16 @@ export interface UpdateUserFormBody {
 
 	auditlog: string;
 }
+
+export interface UpdateSettingsFormBody {
+	authMode: "2fa" | "password";
+	signUpMode: "closed" | "open" | "invite";
+
+	storage: string;
+	uploadSize: string;
+
+	extensions: string[];
+	extensionsMode: "block" | "pass";
+
+	auditlog: string;
+}

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -84,6 +84,28 @@ const AdminSettingsPanel: NextPage = () => {
 		return undefined;
 	};
 
+	const deleteInviteCode = async (invites: string[]) => {
+		const promise = async () => {
+			try {
+				await axios.delete<Invite>("/api/invites/create", { data: { invites } });
+			} catch (err) {
+				const _error = "isAxiosError" in err ? (err as AxiosError<{ message: string }>).response?.data.message : "";
+				const error = _error || "Unknown error, please try again later.";
+				console.log(error);
+
+				throw new Error();
+			}
+		};
+
+		try {
+			await toast.promise(promise(), {
+				pending: "Removing someone from the party...",
+				error: "Everyone left the party instead :(",
+				success: "Someone left the party."
+			});
+		} catch (error) {}
+	};
+
 	const [inviteModal, setInviteModal] = useState(false);
 	const enableInviteModal = () => setInviteModal(true);
 	const disableInviteModal = () => setInviteModal(false);
@@ -94,6 +116,7 @@ const AdminSettingsPanel: NextPage = () => {
 				isOpen={inviteModal}
 				onClick={disableInviteModal}
 				createInvite={createInviteCode}
+				deleteInvite={deleteInviteCode}
 				toastSuccess={(str) => toast.success(str)}
 			/>
 			<AdminSettingsForm onSubmit={onSubmit} enableInviteModal={enableInviteModal} />

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -1,7 +1,9 @@
 import type { GetServerSideProps, NextPage } from "next";
-import { AdminLayout, AdminSettingsForm } from "@paperplane/ui";
-import axios from "axios";
-import { getProtocol } from "@paperplane/utils";
+import { AdminLayout, AdminSettingsForm, SettingsForm } from "@paperplane/ui";
+import axios, { AxiosError } from "axios";
+import { getProtocol, parseToDay } from "@paperplane/utils";
+import type { FormikHelpers } from "formik";
+import { toast } from "react-toastify";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
 	const stateRes = await axios.get<{ admin: boolean; domain: boolean }>(`${getProtocol()}${context.req.headers.host}/api/auth/state`, {
@@ -22,9 +24,41 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 const AdminSettingsPanel: NextPage = () => {
+	const _onSubmitBulk = async (values: SettingsForm, helpers: FormikHelpers<SettingsForm>) => {
+		try {
+			await axios.post("/api/admin/settings", {
+				...values,
+				auditlog: parseToDay(values.auditlog, values.auditlogUnit),
+				storage: `${values.storage} ${values.storageUnit}`,
+				uploadSize: `${values.uploadSize} ${values.uploadSizeUnit}`
+			});
+		} catch (err) {
+			const _error = "isAxiosError" in err ? (err as AxiosError<{ message: string }>).response?.data.message : "";
+			const error = _error || "Unknown error, please try again later.";
+			helpers.resetForm({
+				values,
+				errors: Object.keys(values)
+					.map((key) => ({ [key]: error }))
+					.reduce((a, b) => ({ ...a, ...b }), {})
+			});
+
+			throw new Error();
+		}
+	};
+
+	const onSubmit = async (values: SettingsForm, helpers: FormikHelpers<SettingsForm>) => {
+		try {
+			await toast.promise(_onSubmitBulk(values, helpers), {
+				pending: "Upgrading the PaperPlanes...",
+				error: "A PaperPlane crashed while testing :(",
+				success: "The new PaperPlanes are ready to use."
+			});
+		} catch (error) {}
+	};
+
 	return (
 		<AdminLayout>
-			<AdminSettingsForm onSubmit={console.log} />
+			<AdminSettingsForm onSubmit={onSubmit} />
 		</AdminLayout>
 	);
 };

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -1,0 +1,32 @@
+import type { GetServerSideProps, NextPage } from "next";
+import { AdminLayout, AdminSettingsForm } from "@paperplane/ui";
+import axios from "axios";
+import { getProtocol } from "@paperplane/utils";
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+	const stateRes = await axios.get<{ admin: boolean; domain: boolean }>(`${getProtocol()}${context.req.headers.host}/api/auth/state`, {
+		headers: { "X-PAPERPLANE-ADMIN-KEY": context.req.cookies["PAPERPLANE-ADMIN"] }
+	});
+
+	if (!stateRes.data.admin)
+		return {
+			redirect: {
+				destination: "/login?user=admin",
+				permanent: false
+			}
+		};
+
+	return {
+		props: {}
+	};
+};
+
+const AdminSettingsPanel: NextPage = () => {
+	return (
+		<AdminLayout>
+			<AdminSettingsForm onSubmit={console.log} />
+		</AdminLayout>
+	);
+};
+
+export default AdminSettingsPanel;

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -1,5 +1,5 @@
 import type { GetServerSideProps, NextPage } from "next";
-import { AdminLayout, AdminSettingsForm, InvitesModal, SettingsForm } from "@paperplane/ui";
+import { AdminDomains, AdminLayout, AdminSettingsForm, InvitesModal, SettingsForm } from "@paperplane/ui";
 import axios, { AxiosError } from "axios";
 import { getProtocol, Invite, parseToDay } from "@paperplane/utils";
 import type { FormikHelpers } from "formik";
@@ -120,6 +120,7 @@ const AdminSettingsPanel: NextPage = () => {
 				toastSuccess={(str) => toast.success(str)}
 			/>
 			<AdminSettingsForm onSubmit={onSubmit} enableInviteModal={enableInviteModal} />
+			<AdminDomains />
 		</AdminLayout>
 	);
 };

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -1,5 +1,5 @@
 import type { GetServerSideProps, NextPage } from "next";
-import { AdminDomains, AdminLayout, AdminSettingsForm, InvitesModal, SettingsForm } from "@paperplane/ui";
+import { AdminBackups, AdminDomains, AdminLayout, AdminResetButtons, AdminSettingsForm, InvitesModal, SettingsForm } from "@paperplane/ui";
 import axios, { AxiosError } from "axios";
 import { getProtocol, Invite, parseToDay } from "@paperplane/utils";
 import type { FormikHelpers } from "formik";
@@ -170,6 +170,8 @@ const AdminSettingsPanel: NextPage = () => {
 			/>
 			<AdminSettingsForm onSubmit={onSubmit} enableInviteModal={enableInviteModal} />
 			<AdminDomains createDomain={createDomain} deleteDomain={deleteDomain} toastSuccess={(str) => toast.success(str)} />
+			<AdminBackups />
+			<AdminResetButtons />
 		</AdminLayout>
 	);
 };

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -109,7 +109,7 @@ const AdminSettingsPanel: NextPage = () => {
 	const createDomain = async (data: { domain: string }, helpers: FormikHelpers<{ domain: string }>) => {
 		const promise = async () => {
 			try {
-				await axios.post("/api/admin/domains", { data });
+				await axios.post("/api/admin/domains", data);
 			} catch (err) {
 				const _error = "isAxiosError" in err ? (err as AxiosError<{ message: string }>).response?.data.message : "";
 				const error = _error || "Unknown error, please try again later.";

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -90,7 +90,12 @@ const AdminSettingsPanel: NextPage = () => {
 
 	return (
 		<AdminLayout>
-			<InvitesModal isOpen={inviteModal} onClick={disableInviteModal} createInvite={createInviteCode} />
+			<InvitesModal
+				isOpen={inviteModal}
+				onClick={disableInviteModal}
+				createInvite={createInviteCode}
+				toastSuccess={(str) => toast.success(str)}
+			/>
 			<AdminSettingsForm onSubmit={onSubmit} enableInviteModal={enableInviteModal} />
 		</AdminLayout>
 	);

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -1,9 +1,10 @@
 import type { GetServerSideProps, NextPage } from "next";
-import { AdminLayout, AdminSettingsForm, SettingsForm } from "@paperplane/ui";
+import { AdminLayout, AdminSettingsForm, InvitesModal, SettingsForm } from "@paperplane/ui";
 import axios, { AxiosError } from "axios";
 import { getProtocol, parseToDay } from "@paperplane/utils";
 import type { FormikHelpers } from "formik";
 import { toast } from "react-toastify";
+import { useState } from "react";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
 	const stateRes = await axios.get<{ admin: boolean; domain: boolean }>(`${getProtocol()}${context.req.headers.host}/api/auth/state`, {
@@ -56,9 +57,14 @@ const AdminSettingsPanel: NextPage = () => {
 		} catch (error) {}
 	};
 
+	const [inviteModal, setInviteModal] = useState(false);
+	const enableInviteModal = () => setInviteModal(true);
+	const disableInviteModal = () => setInviteModal(false);
+
 	return (
 		<AdminLayout>
-			<AdminSettingsForm onSubmit={onSubmit} />
+			<InvitesModal isOpen={inviteModal} onClick={disableInviteModal} />
+			<AdminSettingsForm onSubmit={onSubmit} enableInviteModal={enableInviteModal} />
 		</AdminLayout>
 	);
 };

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -106,6 +106,33 @@ const AdminSettingsPanel: NextPage = () => {
 		} catch (error) {}
 	};
 
+	const createDomain = async (data: { domain: string }, helpers: FormikHelpers<{ domain: string }>) => {
+		const promise = async () => {
+			try {
+				await axios.post("/api/admin/domains", { data });
+			} catch (err) {
+				const _error = "isAxiosError" in err ? (err as AxiosError<{ message: string }>).response?.data.message : "";
+				const error = _error || "Unknown error, please try again later.";
+				helpers.resetForm({
+					values: data,
+					errors: Object.keys(data)
+						.map((key) => ({ [key]: error }))
+						.reduce((a, b) => ({ ...a, ...b }), {})
+				});
+
+				throw new Error();
+			}
+		};
+
+		try {
+			await toast.promise(promise(), {
+				pending: "Building new hanger...",
+				error: "Hanger collapsed during the construction :(",
+				success: "New hanger is completed and ready to use!."
+			});
+		} catch (error) {}
+	};
+
 	const [inviteModal, setInviteModal] = useState(false);
 	const enableInviteModal = () => setInviteModal(true);
 	const disableInviteModal = () => setInviteModal(false);
@@ -120,7 +147,7 @@ const AdminSettingsPanel: NextPage = () => {
 				toastSuccess={(str) => toast.success(str)}
 			/>
 			<AdminSettingsForm onSubmit={onSubmit} enableInviteModal={enableInviteModal} />
-			<AdminDomains />
+			<AdminDomains createDomain={createDomain} toastSuccess={(str) => toast.success(str)} />
 		</AdminLayout>
 	);
 };

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -106,6 +106,28 @@ const AdminSettingsPanel: NextPage = () => {
 		} catch (error) {}
 	};
 
+	const deleteDomain = async (domains: string[]) => {
+		const promise = async () => {
+			try {
+				await axios.delete("/api/admin/domains", { data: { domains } });
+			} catch (err) {
+				const _error = "isAxiosError" in err ? (err as AxiosError<{ message: string }>).response?.data.message : "";
+				const error = _error || "Unknown error, please try again later.";
+				console.log(error);
+
+				throw new Error();
+			}
+		};
+
+		try {
+			await toast.promise(promise(), {
+				pending: "Destroying hangers...",
+				error: "One of the hangers was to strong :(",
+				success: "Hangers destroyed! Mission Successful."
+			});
+		} catch (error) {}
+	};
+
 	const createDomain = async (data: { domain: string }, helpers: FormikHelpers<{ domain: string }>) => {
 		const promise = async () => {
 			try {
@@ -147,7 +169,7 @@ const AdminSettingsPanel: NextPage = () => {
 				toastSuccess={(str) => toast.success(str)}
 			/>
 			<AdminSettingsForm onSubmit={onSubmit} enableInviteModal={enableInviteModal} />
-			<AdminDomains createDomain={createDomain} toastSuccess={(str) => toast.success(str)} />
+			<AdminDomains createDomain={createDomain} deleteDomain={deleteDomain} toastSuccess={(str) => toast.success(str)} />
 		</AdminLayout>
 	);
 };

--- a/apps/web/src/pages/admin/settings.tsx
+++ b/apps/web/src/pages/admin/settings.tsx
@@ -1,7 +1,7 @@
 import type { GetServerSideProps, NextPage } from "next";
 import { AdminLayout, AdminSettingsForm, InvitesModal, SettingsForm } from "@paperplane/ui";
 import axios, { AxiosError } from "axios";
-import { getProtocol, parseToDay } from "@paperplane/utils";
+import { getProtocol, Invite, parseToDay } from "@paperplane/utils";
 import type { FormikHelpers } from "formik";
 import { toast } from "react-toastify";
 import { useState } from "react";
@@ -57,13 +57,40 @@ const AdminSettingsPanel: NextPage = () => {
 		} catch (error) {}
 	};
 
+	const createInviteCode = async () => {
+		const promise = async () => {
+			try {
+				const res = await axios.post<Invite>("/api/invites/create");
+				return res.data;
+			} catch (err) {
+				const _error = "isAxiosError" in err ? (err as AxiosError<{ message: string }>).response?.data.message : "";
+				const error = _error || "Unknown error, please try again later.";
+				console.log(error);
+
+				throw new Error();
+			}
+		};
+
+		try {
+			const res = await toast.promise(promise(), {
+				pending: "Inviting all PaperPlanes...",
+				error: "The carrier pigeons failed to deliver the invites :(",
+				success: "All PaperPlanes invited!"
+			});
+
+			return res;
+		} catch (error) {}
+
+		return undefined;
+	};
+
 	const [inviteModal, setInviteModal] = useState(false);
 	const enableInviteModal = () => setInviteModal(true);
 	const disableInviteModal = () => setInviteModal(false);
 
 	return (
 		<AdminLayout>
-			<InvitesModal isOpen={inviteModal} onClick={disableInviteModal} />
+			<InvitesModal isOpen={inviteModal} onClick={disableInviteModal} createInvite={createInviteCode} />
 			<AdminSettingsForm onSubmit={onSubmit} enableInviteModal={enableInviteModal} />
 		</AdminLayout>
 	);

--- a/packages/swr/src/useSwr.ts
+++ b/packages/swr/src/useSwr.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import UseSwr from "swr";
 import type { FetcherResponse, PublicConfiguration } from "swr/_internal";
 
-export const defaultFetcher = (url: string) => axios.get(url).then((res) => res.data);
+export const defaultFetcher = (url: string) => axios.get(url, { withCredentials: true }).then((res) => res.data);
 
 export const useSwr = <Response = any, Error = any>(
 	url: string,

--- a/packages/swr/src/useSwr.ts
+++ b/packages/swr/src/useSwr.ts
@@ -9,7 +9,7 @@ export const useSwr = <Response = any, Error = any>(
 	options?: Partial<PublicConfiguration<Response, Error, (args: string) => FetcherResponse<Response>>>,
 	fetcher = defaultFetcher
 ) => {
-	const swr = UseSwr<Response, Error, string>(url, fetcher, options);
+	const swr = UseSwr<Response, Error, string>(url, fetcher, { revalidateOnFocus: false, ...options });
 	return swr;
 };
 
@@ -18,6 +18,6 @@ export const useSwrWithUpdates = <Response = any, Error = any>(
 	options?: Partial<PublicConfiguration<Response, Error, (args: string) => FetcherResponse<Response>>>,
 	fetcher = defaultFetcher
 ) => {
-	const swr = UseSwr<Response, Error, string>(url, fetcher, { refreshInterval: 5e3, ...options });
+	const swr = UseSwr<Response, Error, string>(url, fetcher, { refreshInterval: 5e3, revalidateOnFocus: false, ...options });
 	return swr;
 };

--- a/packages/ui/src/admin/Layout.tsx
+++ b/packages/ui/src/admin/Layout.tsx
@@ -10,7 +10,7 @@ export const AdminLayout: React.FC<React.PropsWithChildren<Props>> = ({ children
 		<>
 			<AdminNavbar />
 			<div className="pt-24 grid place-items-center">
-				<div className={`pt-24 flex flex-col justify-center items-center gap-y-8 max-md:pt-8 max-w-[1040px] w-full px-2 ${className}`}>
+				<div className={`pt-24 pb-8 flex flex-col justify-center items-center gap-y-8 max-md:pt-8 max-w-[1040px] w-full px-2 ${className}`}>
 					{children}
 				</div>
 			</div>

--- a/packages/ui/src/admin/UserList/CreateUserModal.tsx
+++ b/packages/ui/src/admin/UserList/CreateUserModal.tsx
@@ -45,8 +45,8 @@ export const CreateUserModal: React.FC<Props> = ({ onSubmit, isOpen, onClick }) 
 		uploadSizeUnit: "GB",
 		extensions: [],
 		extensionsMode: "block",
-		auditlog: 1,
-		auditlogUnit: "mth"
+		auditlog: 31,
+		auditlogUnit: "d"
 	});
 	const [domains, setDomains] = useState<string[]>([]);
 	const { data: createGetData } = useSwr<CreateGetApi>("/api/admin/create", undefined, (url) =>

--- a/packages/ui/src/admin/UserList/CreateUserModal.tsx
+++ b/packages/ui/src/admin/UserList/CreateUserModal.tsx
@@ -178,7 +178,7 @@ export const CreateUserModal: React.FC<Props> = ({ onSubmit, isOpen, onClick }) 
 												className="w-full"
 												options={STORAGE_UNITS.map((unit) => ({ value: unit, label: unit }))}
 												onChange={(value) => formik.setFieldValue("storageUnit", (value as SelectOption).value)}
-												defaultValue={{ label: formik.initialValues.storageUnit, value: formik.initialValues.storageUnit }}
+												value={{ label: formik.values.storageUnit, value: formik.values.storageUnit }}
 											/>
 											<p className="text-red text-left text-small font-normal">
 												{formik.errors.storageUnit && `* ${formik.errors.storageUnit}`}&#8203;
@@ -216,9 +216,9 @@ export const CreateUserModal: React.FC<Props> = ({ onSubmit, isOpen, onClick }) 
 												className="w-full"
 												options={STORAGE_UNITS.map((unit) => ({ value: unit, label: unit }))}
 												onChange={(value) => formik.setFieldValue("uploadSizeUnit", (value as SelectOption).value)}
-												defaultValue={{
-													label: formik.initialValues.uploadSizeUnit,
-													value: formik.initialValues.uploadSizeUnit
+												value={{
+													label: formik.values.uploadSizeUnit,
+													value: formik.values.uploadSizeUnit
 												}}
 											/>
 											<p className="text-red text-left text-small font-normal">
@@ -260,9 +260,9 @@ export const CreateUserModal: React.FC<Props> = ({ onSubmit, isOpen, onClick }) 
 													{ label: "Mode: pass", value: "pass" }
 												]}
 												onChange={(value) => formik.setFieldValue("extensionsMode", (value as SelectOption).value)}
-												defaultValue={{
-													label: `Mode: ${formik.initialValues.extensionsMode}`,
-													value: formik.initialValues.extensionsMode
+												value={{
+													label: `Mode: ${formik.values.extensionsMode}`,
+													value: formik.values.extensionsMode
 												}}
 											/>
 											<p className="text-red text-left text-small font-normal">
@@ -300,7 +300,7 @@ export const CreateUserModal: React.FC<Props> = ({ onSubmit, isOpen, onClick }) 
 												placeholder="Select a unit"
 												className="w-full"
 												options={TIME_UNITS}
-												defaultValue={TIME_UNITS.find((unit) => unit.value === formik.initialValues.auditlogUnit)}
+												value={TIME_UNITS.find((unit) => unit.value === formik.values.auditlogUnit)}
 												onChange={(value) => formik.setFieldValue("auditlogUnit", (value as SelectOption).value)}
 											/>
 											<p className="text-red text-left text-small font-normal">

--- a/packages/ui/src/admin/UserList/UpdateUserModal.tsx
+++ b/packages/ui/src/admin/UserList/UpdateUserModal.tsx
@@ -44,8 +44,8 @@ export const UpdateUserModal: React.FC<Props> = ({ domains, onSubmit, isOpen, on
 		uploadSizeUnit: "GB",
 		extensions: [],
 		extensionsMode: "block",
-		auditlog: 1,
-		auditlogUnit: "mth"
+		auditlog: 31,
+		auditlogUnit: "d"
 	});
 	const { data: createGetData } = useSwr<CreateGetApi>(
 		domains.length === 1 ? `/api/admin/domain?domain=${domains[0]}` : "/api/admin/create",

--- a/packages/ui/src/admin/UserList/UpdateUserModal.tsx
+++ b/packages/ui/src/admin/UserList/UpdateUserModal.tsx
@@ -158,9 +158,9 @@ export const UpdateUserModal: React.FC<Props> = ({ domains, onSubmit, isOpen, on
 												className="w-full"
 												options={STORAGE_UNITS.map((unit) => ({ value: unit, label: unit }))}
 												onChange={(value) => formik.setFieldValue("storageUnit", (value as SelectOption).value)}
-												defaultValue={{
-													label: formik.initialValues.storageUnit,
-													value: formik.initialValues.storageUnit
+												value={{
+													label: formik.values.storageUnit,
+													value: formik.values.storageUnit
 												}}
 											/>
 											<p className="text-red text-left text-small font-normal">
@@ -199,9 +199,9 @@ export const UpdateUserModal: React.FC<Props> = ({ domains, onSubmit, isOpen, on
 												className="w-full"
 												options={STORAGE_UNITS.map((unit) => ({ value: unit, label: unit }))}
 												onChange={(value) => formik.setFieldValue("uploadSizeUnit", (value as SelectOption).value)}
-												defaultValue={{
-													label: formik.initialValues.uploadSizeUnit,
-													value: formik.initialValues.uploadSizeUnit
+												value={{
+													label: formik.values.uploadSizeUnit,
+													value: formik.values.uploadSizeUnit
 												}}
 											/>
 											<p className="text-red text-left text-small font-normal">
@@ -243,9 +243,9 @@ export const UpdateUserModal: React.FC<Props> = ({ domains, onSubmit, isOpen, on
 													{ label: "Mode: pass", value: "pass" }
 												]}
 												onChange={(value) => formik.setFieldValue("extensionsMode", (value as SelectOption).value)}
-												defaultValue={{
-													label: `Mode: ${formik.initialValues.extensionsMode}`,
-													value: formik.initialValues.extensionsMode
+												value={{
+													label: `Mode: ${formik.values.extensionsMode}`,
+													value: formik.values.extensionsMode
 												}}
 											/>
 											<p className="text-red text-left text-small font-normal">
@@ -283,7 +283,7 @@ export const UpdateUserModal: React.FC<Props> = ({ domains, onSubmit, isOpen, on
 												placeholder="Select a unit"
 												className="w-full"
 												options={TIME_UNITS}
-												defaultValue={TIME_UNITS.find((unit) => unit.value === formik.initialValues.auditlogUnit)}
+												value={TIME_UNITS.find((unit) => unit.value === formik.values.auditlogUnit)}
 												onChange={(value) => formik.setFieldValue("auditlogUnit", (value as SelectOption).value)}
 											/>
 											<p className="text-red text-left text-small font-normal">

--- a/packages/ui/src/admin/index.ts
+++ b/packages/ui/src/admin/index.ts
@@ -5,3 +5,4 @@ export * from "./Usage";
 export * from "./DeleteBanner";
 
 export * from "./UserList";
+export * from "./settings";

--- a/packages/ui/src/admin/settings/Backups.tsx
+++ b/packages/ui/src/admin/settings/Backups.tsx
@@ -1,0 +1,56 @@
+import { DangerButton } from "@paperplane/buttons";
+import type React from "react";
+
+interface Props {}
+
+export const AdminBackups: React.FC<Props> = () => {
+	// const [isOpen, setIsOpen] = useState(false);
+	// const [page, setPage] = useState(0);
+	// const [selected, setSelected] = useState<string[]>([]);
+	// const [domains, setDomains] = useState<SignUpDomainGetApi>({ entries: [], pages: 0 });
+	// const { data: domainsGetData, mutate } = useSwrWithUpdates<SignUpDomainGetApi>(`/api/admin/domains?page=${page}`, {
+	// 	refreshInterval: isOpen ? 5e3 : 0
+	// });
+
+	// useEffect(() => {
+	// 	if (domainsGetData) setDomains(domainsGetData);
+	// }, [domainsGetData]);
+
+	// const createBackup = async () => {
+	// await _createBackup();
+	// await mutate();
+	// };
+
+	// const pageOptions: SelectOption[] = Array(domains.pages)
+	// 	.fill(null)
+	// 	.map((_, key) => ({ label: `Page ${key + 1}`, value: key.toString() }));
+	// const pageValue: SelectOption = { label: `Page ${page + 1}`, value: page.toString() };
+
+	// const previousPage = () => setPage(page - 1);
+	// const nextPage = () => setPage(page + 1);
+	// const onPageChange = (option: any) => {
+	// 	if (typeof option !== "object") return;
+	// 	const { value } = option as SelectOption;
+
+	// 	setPage(Number(value));
+	// };
+
+	return (
+		<>
+			<div className="max-w-[50vw] max-xl:max-w-[75vw] max-md:max-w-[100vw] w-full">
+				<div className="w-full">
+					<h1 className="text-xl">Backups</h1>
+					<p className="text-base">
+						You can make a backup any time, we currently do not support automatic backups. You can find the backup files in the{" "}
+						<strong>/backups</strong> directory on the server. To import a backup, move one to the folder or use an already created
+						backup, press the import backup button and select it from the list.
+					</p>
+				</div>
+				<div className="w-full mt-4 flex items-center gap-2">
+					<DangerButton type="button">Create Backup</DangerButton>
+					<DangerButton type="button">Import Backup</DangerButton>
+				</div>
+			</div>
+		</>
+	);
+};

--- a/packages/ui/src/admin/settings/Domains.tsx
+++ b/packages/ui/src/admin/settings/Domains.tsx
@@ -12,10 +12,11 @@ import { Table, TableEntry } from "../../index";
 
 interface Props {
 	createDomain: (...props: any) => Promise<void>;
+	deleteDomain: (domains: string[]) => Promise<void>;
 	toastSuccess: (str: string) => void;
 }
 
-export const AdminDomains: React.FC<Props> = ({ createDomain: _createDomain, toastSuccess }) => {
+export const AdminDomains: React.FC<Props> = ({ createDomain: _createDomain, deleteDomain, toastSuccess }) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [page, setPage] = useState(0);
 	const [selected, setSelected] = useState<string[]>([]);
@@ -54,12 +55,12 @@ export const AdminDomains: React.FC<Props> = ({ createDomain: _createDomain, toa
 	};
 
 	const onSingleDelete = async (invite: string) => {
-		// await deleteInvite([invite]);
+		await deleteDomain([invite]);
 		await mutate();
 	};
 
 	const onBulkDelete = async () => {
-		// await deleteInvite(selected);
+		await deleteDomain(selected);
 		await mutate();
 	};
 

--- a/packages/ui/src/admin/settings/Domains.tsx
+++ b/packages/ui/src/admin/settings/Domains.tsx
@@ -15,7 +15,7 @@ interface Props {
 	toastSuccess: (str: string) => void;
 }
 
-export const AdminDomains: React.FC<Props> = ({ createDomain, toastSuccess }) => {
+export const AdminDomains: React.FC<Props> = ({ createDomain: _createDomain, toastSuccess }) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [page, setPage] = useState(0);
 	const [selected, setSelected] = useState<string[]>([]);
@@ -35,7 +35,6 @@ export const AdminDomains: React.FC<Props> = ({ createDomain, toastSuccess }) =>
 				test: (str) => {
 					if (!str) return false;
 					if (str.startsWith(".") || str.endsWith(".") || str.startsWith("-")) return false;
-					if (!str.includes(".")) return false;
 
 					return true;
 				},
@@ -61,6 +60,11 @@ export const AdminDomains: React.FC<Props> = ({ createDomain, toastSuccess }) =>
 
 	const onBulkDelete = async () => {
 		// await deleteInvite(selected);
+		await mutate();
+	};
+
+	const createDomain = async (...props: any) => {
+		await _createDomain(...props);
 		await mutate();
 	};
 

--- a/packages/ui/src/admin/settings/Domains.tsx
+++ b/packages/ui/src/admin/settings/Domains.tsx
@@ -1,0 +1,19 @@
+import { PrimaryButton } from "@paperplane/buttons";
+import type React from "react";
+
+export const AdminDomains: React.FC = () => {
+	return (
+		<div className="max-w-[50vw] max-xl:max-w-[75vw] max-md:max-w-[100vw] w-full">
+			<div className="w-full">
+				<h1 className="text-xl">Available Domains</h1>
+				<p className="text-base">
+					To make sign ups/account creation possible, a domain (or multiple) have to be assigned to PaperPlane. You can assign a single
+					domain, domain with subdomain or multiple of each.
+				</p>
+			</div>
+			<div className="w-full mt-4">
+				<PrimaryButton type="button">Open available domains list</PrimaryButton>
+			</div>
+		</div>
+	);
+};

--- a/packages/ui/src/admin/settings/Domains.tsx
+++ b/packages/ui/src/admin/settings/Domains.tsx
@@ -1,19 +1,172 @@
-import { PrimaryButton } from "@paperplane/buttons";
+import { DangerButton, PrimaryButton, TransparentButton } from "@paperplane/buttons";
+import { Input, SelectMenu, SelectOption } from "@paperplane/forms";
+import { Modal } from "@paperplane/modal";
+import { useSwrWithUpdates } from "@paperplane/swr";
+import { formatDate, SignUpDomainGetApi } from "@paperplane/utils";
+import { Form, Formik } from "formik";
 import type React from "react";
+import { useEffect, useState } from "react";
+import { PulseLoader } from "react-spinners";
+import { object, string } from "yup";
+import { Table, TableEntry } from "../../index";
 
-export const AdminDomains: React.FC = () => {
+interface Props {
+	createDomain: (...props: any) => Promise<void>;
+	toastSuccess: (str: string) => void;
+}
+
+export const AdminDomains: React.FC<Props> = ({ createDomain, toastSuccess }) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const [page, setPage] = useState(0);
+	const [selected, setSelected] = useState<string[]>([]);
+	const [domains, setDomains] = useState<SignUpDomainGetApi>({ entries: [], pages: 0 });
+	const { data: domainsGetData, mutate } = useSwrWithUpdates<SignUpDomainGetApi>(`/api/admin/domains?page=${page}`, {
+		refreshInterval: isOpen ? 5e3 : 0
+	});
+
+	useEffect(() => {
+		if (domainsGetData) setDomains(domainsGetData);
+	}, [domainsGetData]);
+
+	const schema = object({
+		domain: string()
+			.required("Domain is a required option")
+			.test({
+				test: (str) => {
+					if (!str) return false;
+					if (str.startsWith(".") || str.endsWith(".") || str.startsWith("-")) return false;
+					if (!str.includes(".")) return false;
+
+					return true;
+				},
+				name: "Basic Domain test",
+				message: "Invalid domain provided"
+			})
+	});
+
+	const copyClipboard = (str: string) => {
+		navigator.clipboard.writeText(str);
+		toastSuccess("Copied to clipboard!");
+	};
+
+	const onSelectClick = (domain: string) => {
+		if (selected.includes(domain)) setSelected(selected.filter((inv) => inv !== domain));
+		else setSelected([domain, ...selected]);
+	};
+
+	const onSingleDelete = async (invite: string) => {
+		// await deleteInvite([invite]);
+		await mutate();
+	};
+
+	const onBulkDelete = async () => {
+		// await deleteInvite(selected);
+		await mutate();
+	};
+
+	const pageOptions: SelectOption[] = Array(domains.pages)
+		.fill(null)
+		.map((_, key) => ({ label: `Page ${key + 1}`, value: key.toString() }));
+	const pageValue: SelectOption = { label: `Page ${page + 1}`, value: page.toString() };
+
+	const previousPage = () => setPage(page - 1);
+	const nextPage = () => setPage(page + 1);
+	const onPageChange = (option: any) => {
+		if (typeof option !== "object") return;
+		const { value } = option as SelectOption;
+
+		setPage(Number(value));
+	};
+
 	return (
-		<div className="max-w-[50vw] max-xl:max-w-[75vw] max-md:max-w-[100vw] w-full">
-			<div className="w-full">
-				<h1 className="text-xl">Available Domains</h1>
-				<p className="text-base">
-					To make sign ups/account creation possible, a domain (or multiple) have to be assigned to PaperPlane. You can assign a single
-					domain, domain with subdomain or multiple of each.
-				</p>
+		<>
+			<Modal isOpen={isOpen} onClick={() => setIsOpen(false)}>
+				<div className="w-[60vw] max-xl:w-[80vw]">
+					<div className="flex items-center justify-between max-sm:flex-col">
+						<h1 className="text-3xl">SignUp Domains</h1>
+						<div className="flex gap-4">
+							<TransparentButton type="button" onClick={previousPage} disabled={page <= 0}>
+								<i className="fa-solid fa-angle-left text-lg" />
+							</TransparentButton>
+							<SelectMenu type="main" placeholder="page" options={pageOptions} value={pageValue} onChange={onPageChange} />
+							<TransparentButton type="button" onClick={nextPage} disabled={page >= domains.pages - 1}>
+								<i className="fa-solid fa-angle-right text-lg" />
+							</TransparentButton>
+						</div>
+					</div>
+					<div className="max-h-[45vh] overflow-auto w-full">
+						<Table className="w-full" colgroups={[325, 300, 100]} headPosition="left" heads={["Domain", "Date", "Options"]}>
+							{domains.entries.map((domain) => (
+								<TableEntry key={domain.domain}>
+									<td>
+										<p title={domain.domain} className="max-w-[300px] overflow-hidden whitespace-nowrap text-ellipsis text-base">
+											{domain.domain}
+										</p>
+									</td>
+									<td>{formatDate(domain.date)}</td>
+									<td className="flex items-center gap-2">
+										<TransparentButton type="button" onClick={() => copyClipboard(domain.domain)}>
+											<i className="fa-solid fa-copy text-base" />
+										</TransparentButton>
+										<TransparentButton type="button" onClick={() => void onSingleDelete(domain.domain)}>
+											<i className="fa-solid fa-trash-can text-base" />
+										</TransparentButton>
+										<input
+											type="checkbox"
+											checked={selected.includes(domain.domain)}
+											onChange={() => onSelectClick(domain.domain)}
+										/>
+									</td>
+								</TableEntry>
+							))}
+						</Table>
+					</div>
+					<div className="mt-4 flex gap-2 justify-center flex-col">
+						<Formik initialValues={{ domain: "" }} validationSchema={schema} onSubmit={createDomain}>
+							{(formik) => (
+								<Form className="flex items-center justify-between w-full">
+									<div className="w-3/4">
+										<Input
+											className="h-[45px] w-full"
+											type="primary"
+											placeholder="Example: *.ijskoud.dev,cdn.ijskoud.dev"
+											value={formik.values.domain}
+											onChange={(ctx) => formik.setFieldValue("domain", ctx.currentTarget.value)}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.domain && `* ${formik.errors.domain}`}&#8203;
+										</p>
+									</div>
+									<div className="w-fit">
+										<PrimaryButton type="button" disabled={formik.isSubmitting || !formik.isValid} onClick={formik.submitForm}>
+											{formik.isSubmitting ? <PulseLoader color="#fff" /> : <>Create new domain</>}
+										</PrimaryButton>
+										<p className="text-red text-left text-small font-normal">&#8203;</p>
+									</div>
+								</Form>
+							)}
+						</Formik>
+
+						<DangerButton type="button" onClick={onBulkDelete}>
+							Delete Selected Domains
+						</DangerButton>
+					</div>
+				</div>
+			</Modal>
+			<div className="max-w-[50vw] max-xl:max-w-[75vw] max-md:max-w-[100vw] w-full">
+				<div className="w-full">
+					<h1 className="text-xl">Available Domains</h1>
+					<p className="text-base">
+						To make sign ups/account creation possible, a domain (or multiple) have to be assigned to PaperPlane. You can assign a single
+						domain, domain with subdomain or multiple of each.
+					</p>
+				</div>
+				<div className="w-full mt-4">
+					<PrimaryButton type="button" onClick={() => setIsOpen(true)}>
+						Open available domains list
+					</PrimaryButton>
+				</div>
 			</div>
-			<div className="w-full mt-4">
-				<PrimaryButton type="button">Open available domains list</PrimaryButton>
-			</div>
-		</div>
+		</>
 	);
 };

--- a/packages/ui/src/admin/settings/Domains.tsx
+++ b/packages/ui/src/admin/settings/Domains.tsx
@@ -129,8 +129,8 @@ export const AdminDomains: React.FC<Props> = ({ createDomain: _createDomain, del
 					<div className="mt-4 flex gap-2 justify-center flex-col">
 						<Formik initialValues={{ domain: "" }} validationSchema={schema} onSubmit={createDomain}>
 							{(formik) => (
-								<Form className="flex items-center justify-between w-full">
-									<div className="w-3/4">
+								<Form className="flex items-center justify-between w-full max-lg:flex-col">
+									<div className="w-3/4 max-lg:w-full">
 										<Input
 											className="h-[45px] w-full"
 											type="primary"
@@ -142,8 +142,13 @@ export const AdminDomains: React.FC<Props> = ({ createDomain: _createDomain, del
 											{formik.errors.domain && `* ${formik.errors.domain}`}&#8203;
 										</p>
 									</div>
-									<div className="w-fit">
-										<PrimaryButton type="button" disabled={formik.isSubmitting || !formik.isValid} onClick={formik.submitForm}>
+									<div className="w-fit max-lg:w-full">
+										<PrimaryButton
+											type="button"
+											className="max-lg:w-full"
+											disabled={formik.isSubmitting || !formik.isValid}
+											onClick={formik.submitForm}
+										>
 											{formik.isSubmitting ? <PulseLoader color="#fff" /> : <>Create new domain</>}
 										</PrimaryButton>
 										<p className="text-red text-left text-small font-normal">&#8203;</p>

--- a/packages/ui/src/admin/settings/InvitesModal.tsx
+++ b/packages/ui/src/admin/settings/InvitesModal.tsx
@@ -1,132 +1,62 @@
 import { PrimaryButton, TransparentButton } from "@paperplane/buttons";
 import { Modal } from "@paperplane/modal";
-import { formatDate } from "@paperplane/utils";
+import { useSwrWithUpdates } from "@paperplane/swr";
+import { formatDate, Invite, InviteGetApi } from "@paperplane/utils";
 import type React from "react";
+import { useEffect, useState } from "react";
 import { Table, TableEntry } from "../../index";
 
 interface Props {
 	isOpen: boolean;
 	onClick: () => void;
+
+	createInvite: () => Promise<Invite | undefined>;
 }
 
-export const InvitesModal: React.FC<Props> = ({ isOpen, onClick }) => {
+export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, createInvite }) => {
+	const [invites, setInvites] = useState<InviteGetApi>({ entries: [], pages: 0 });
+	const { data: invitesGetData, mutate } = useSwrWithUpdates<InviteGetApi>("/api/invites/list");
+
+	useEffect(() => {
+		if (invitesGetData) setInvites(invitesGetData);
+	}, [invitesGetData]);
+
+	const onCreateClick = async () => {
+		const invite = await createInvite();
+		if (invite) await mutate({ ...invites, entries: [invite, ...invites.entries] });
+	};
+
 	return (
 		<Modal onClick={onClick} isOpen={isOpen}>
-			<div className="w-[50vw] max-xl:w-[80vw]">
+			<div className="w-[60vw] max-xl:w-[80vw]">
 				<h1 className="text-3xl">Invite Codes</h1>
 				<div className="max-h-[45vh] overflow-auto w-full">
 					<Table className="w-full" colgroups={[325, 300, 100]} headPosition="left" heads={["Code", "Date", "Options"]}>
-						<TableEntry>
-							<td>
-								<p title="aa" className="max-w-[300px] overflow-hidden whitespace-nowrap text-ellipsis">
-									{"a".repeat(50)}
-								</p>
-							</td>
-							<td>{formatDate(new Date())}</td>
-							<td className="flex items-center gap-2">
-								<TransparentButton type="button">
-									<i className="fa-solid fa-copy text-base" />
-								</TransparentButton>
-								<TransparentButton type="button">
-									<i className="fa-solid fa-trash-can text-base" />
-								</TransparentButton>
-								<input type="checkbox" />
-							</td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
-						<TableEntry>
-							<td>aaaaa</td>
-							<td>{formatDate(new Date())}</td>
-							<td></td>
-						</TableEntry>
+						{invites.entries.map((invite) => (
+							<TableEntry key={invite.invite}>
+								<td>
+									<p title={invite.invite} className="max-w-[300px] overflow-hidden whitespace-nowrap text-ellipsis">
+										{invite.invite}
+									</p>
+								</td>
+								<td>{formatDate(invite.date)}</td>
+								<td className="flex items-center gap-2">
+									<TransparentButton type="button">
+										<i className="fa-solid fa-copy text-base" />
+									</TransparentButton>
+									<TransparentButton type="button">
+										<i className="fa-solid fa-trash-can text-base" />
+									</TransparentButton>
+									<input type="checkbox" />
+								</td>
+							</TableEntry>
+						))}
 					</Table>
 				</div>
 				<div className="mt-4">
-					<PrimaryButton type="button">Create Invite</PrimaryButton>
+					<PrimaryButton type="button" onClick={onCreateClick}>
+						Create Invite
+					</PrimaryButton>
 				</div>
 			</div>
 		</Modal>

--- a/packages/ui/src/admin/settings/InvitesModal.tsx
+++ b/packages/ui/src/admin/settings/InvitesModal.tsx
@@ -1,4 +1,4 @@
-import { PrimaryButton, TransparentButton } from "@paperplane/buttons";
+import { DangerButton, PrimaryButton, TransparentButton } from "@paperplane/buttons";
 import { Modal } from "@paperplane/modal";
 import { useSwrWithUpdates } from "@paperplane/swr";
 import { formatDate, Invite, InviteGetApi } from "@paperplane/utils";
@@ -44,6 +44,11 @@ export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, deleteInvite, c
 		await mutate();
 	};
 
+	const onBulkDelete = async () => {
+		await deleteInvite(selected);
+		await mutate();
+	};
+
 	return (
 		<Modal onClick={onClick} isOpen={isOpen}>
 			<div className="w-[60vw] max-xl:w-[80vw]">
@@ -71,10 +76,13 @@ export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, deleteInvite, c
 						))}
 					</Table>
 				</div>
-				<div className="mt-4">
+				<div className="mt-4 flex gap-2 items-center">
 					<PrimaryButton type="button" onClick={onCreateClick}>
 						Create Invite
 					</PrimaryButton>
+					<DangerButton type="button" onClick={onBulkDelete}>
+						Delete Selected Invites
+					</DangerButton>
 				</div>
 			</div>
 		</Modal>

--- a/packages/ui/src/admin/settings/InvitesModal.tsx
+++ b/packages/ui/src/admin/settings/InvitesModal.tsx
@@ -68,7 +68,7 @@ export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, deleteInvite, c
 	return (
 		<Modal onClick={onClick} isOpen={isOpen}>
 			<div className="w-[60vw] max-xl:w-[80vw]">
-				<div className="flex items-center justify-between">
+				<div className="flex items-center justify-between max-sm:flex-col">
 					<h1 className="text-3xl">Invite Codes</h1>
 					<div className="flex gap-4">
 						<TransparentButton type="button" onClick={previousPage} disabled={page <= 0}>
@@ -85,7 +85,7 @@ export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, deleteInvite, c
 						{invites.entries.map((invite) => (
 							<TableEntry key={invite.invite}>
 								<td>
-									<p title={invite.invite} className="max-w-[300px] overflow-hidden whitespace-nowrap text-ellipsis">
+									<p title={invite.invite} className="max-w-[300px] overflow-hidden whitespace-nowrap text-ellipsis text-base">
 										{invite.invite}
 									</p>
 								</td>
@@ -103,7 +103,7 @@ export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, deleteInvite, c
 						))}
 					</Table>
 				</div>
-				<div className="mt-4 flex gap-2 items-center">
+				<div className="mt-4 flex gap-2 items-center max-sm:flex-col">
 					<PrimaryButton type="button" onClick={onCreateClick}>
 						Create Invite
 					</PrimaryButton>

--- a/packages/ui/src/admin/settings/InvitesModal.tsx
+++ b/packages/ui/src/admin/settings/InvitesModal.tsx
@@ -10,10 +10,11 @@ interface Props {
 	isOpen: boolean;
 	onClick: () => void;
 
+	toastSuccess: (str: string) => void;
 	createInvite: () => Promise<Invite | undefined>;
 }
 
-export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, createInvite }) => {
+export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, createInvite, toastSuccess }) => {
 	const [invites, setInvites] = useState<InviteGetApi>({ entries: [], pages: 0 });
 	const { data: invitesGetData, mutate } = useSwrWithUpdates<InviteGetApi>("/api/invites/list");
 
@@ -24,6 +25,11 @@ export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, createInvite })
 	const onCreateClick = async () => {
 		const invite = await createInvite();
 		if (invite) await mutate({ ...invites, entries: [invite, ...invites.entries] });
+	};
+
+	const copyClipboard = (str: string) => {
+		navigator.clipboard.writeText(str);
+		toastSuccess("Copied to clipboard!");
 	};
 
 	return (
@@ -41,7 +47,7 @@ export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, createInvite })
 								</td>
 								<td>{formatDate(invite.date)}</td>
 								<td className="flex items-center gap-2">
-									<TransparentButton type="button">
+									<TransparentButton type="button" onClick={() => copyClipboard(invite.invite)}>
 										<i className="fa-solid fa-copy text-base" />
 									</TransparentButton>
 									<TransparentButton type="button">

--- a/packages/ui/src/admin/settings/InvitesModal.tsx
+++ b/packages/ui/src/admin/settings/InvitesModal.tsx
@@ -20,7 +20,7 @@ export const InvitesModal: React.FC<Props> = ({ isOpen, onClick, deleteInvite, c
 	const [page, setPage] = useState(0);
 	const [selected, setSelected] = useState<string[]>([]);
 	const [invites, setInvites] = useState<InviteGetApi>({ entries: [], pages: 0 });
-	const { data: invitesGetData, mutate } = useSwrWithUpdates<InviteGetApi>(`/api/invites/list?page=${page}`);
+	const { data: invitesGetData, mutate } = useSwrWithUpdates<InviteGetApi>(`/api/invites/list?page=${page}`, { refreshInterval: isOpen ? 5e3 : 0 });
 
 	useEffect(() => {
 		if (invitesGetData) setInvites(invitesGetData);

--- a/packages/ui/src/admin/settings/InvitesModal.tsx
+++ b/packages/ui/src/admin/settings/InvitesModal.tsx
@@ -1,0 +1,134 @@
+import { PrimaryButton, TransparentButton } from "@paperplane/buttons";
+import { Modal } from "@paperplane/modal";
+import { formatDate } from "@paperplane/utils";
+import type React from "react";
+import { Table, TableEntry } from "../../index";
+
+interface Props {
+	isOpen: boolean;
+	onClick: () => void;
+}
+
+export const InvitesModal: React.FC<Props> = ({ isOpen, onClick }) => {
+	return (
+		<Modal onClick={onClick} isOpen={isOpen}>
+			<div className="w-[50vw] max-xl:w-[80vw]">
+				<h1 className="text-3xl">Invite Codes</h1>
+				<div className="max-h-[45vh] overflow-auto w-full">
+					<Table className="w-full" colgroups={[325, 300, 100]} headPosition="left" heads={["Code", "Date", "Options"]}>
+						<TableEntry>
+							<td>
+								<p title="aa" className="max-w-[300px] overflow-hidden whitespace-nowrap text-ellipsis">
+									{"a".repeat(50)}
+								</p>
+							</td>
+							<td>{formatDate(new Date())}</td>
+							<td className="flex items-center gap-2">
+								<TransparentButton type="button">
+									<i className="fa-solid fa-copy text-base" />
+								</TransparentButton>
+								<TransparentButton type="button">
+									<i className="fa-solid fa-trash-can text-base" />
+								</TransparentButton>
+								<input type="checkbox" />
+							</td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+						<TableEntry>
+							<td>aaaaa</td>
+							<td>{formatDate(new Date())}</td>
+							<td></td>
+						</TableEntry>
+					</Table>
+				</div>
+				<div className="mt-4">
+					<PrimaryButton type="button">Create Invite</PrimaryButton>
+				</div>
+			</div>
+		</Modal>
+	);
+};

--- a/packages/ui/src/admin/settings/ResetButtons.tsx
+++ b/packages/ui/src/admin/settings/ResetButtons.tsx
@@ -1,0 +1,21 @@
+import { DangerButton } from "@paperplane/buttons";
+import type React from "react";
+
+interface Props {}
+
+export const AdminResetButtons: React.FC<Props> = () => {
+	return (
+		<>
+			<div className="max-w-[50vw] max-xl:max-w-[75vw] max-md:max-w-[100vw] w-full">
+				<div className="w-full">
+					<h1 className="text-xl">BIG RED BUTTONS!!</h1>
+					<p className="text-base">Pressing one of the following buttons is very dangerous and once started actions cannot be reverted.</p>
+				</div>
+				<div className="w-full mt-4 flex items-center gap-2">
+					<DangerButton type="button">Reset PaperPlane</DangerButton>
+					<DangerButton type="button">Reset Encryption Key</DangerButton>
+				</div>
+			</div>
+		</>
+	);
+};

--- a/packages/ui/src/admin/settings/SettingsForm.tsx
+++ b/packages/ui/src/admin/settings/SettingsForm.tsx
@@ -1,0 +1,276 @@
+import { PrimaryButton } from "@paperplane/buttons";
+import { Input, SelectMenu, SelectOption } from "@paperplane/forms";
+import { useSwr } from "@paperplane/swr";
+import { SettingsGetApi, formatBytes, STORAGE_UNITS, TIME_UNITS, TIME_UNITS_ARRAY } from "@paperplane/utils";
+import axios from "axios";
+import { Form, Formik } from "formik";
+import ms from "ms";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { PulseLoader } from "react-spinners";
+import { array, number, object, string } from "yup";
+
+interface Props {
+	onSubmit: (...props: any) => void | Promise<void>;
+}
+
+interface SettingsForm {
+	authMode: "2fa" | "password";
+	signUpMode: "closed" | "open" | "invite";
+
+	storage: number;
+	storageUnit: (typeof STORAGE_UNITS)[number];
+
+	uploadSize: number;
+	uploadSizeUnit: (typeof STORAGE_UNITS)[number];
+
+	extensions: string[];
+	extensionsMode: "block" | "pass";
+
+	auditlog: number;
+	auditlogUnit: (typeof TIME_UNITS_ARRAY)[number];
+}
+
+export const AdminSettingsForm: React.FC<Props> = ({ onSubmit }) => {
+	const [initValues, setInitValues] = useState<SettingsForm>({
+		authMode: "2fa",
+		signUpMode: "closed",
+		storage: 0,
+		storageUnit: "GB",
+		uploadSize: 0,
+		uploadSizeUnit: "GB",
+		extensions: [],
+		extensionsMode: "block",
+		auditlog: 1,
+		auditlogUnit: "mth"
+	});
+	const { data: settingsGetData } = useSwr<SettingsGetApi>("/api/admin/settings", undefined, (url) =>
+		axios.get(url, { withCredentials: true }).then((res) => res.data)
+	);
+
+	useEffect(() => {
+		const getStorage = (storage: number): string[] => {
+			const res = formatBytes(storage);
+			return res.split(/ +/g);
+		};
+
+		if (settingsGetData) {
+			const storage = getStorage(settingsGetData.defaults.maxStorage);
+			const upload = getStorage(settingsGetData.defaults.maxUploadSize);
+			const audit = ms(settingsGetData.defaults.auditlog).split("");
+
+			setInitValues({
+				authMode: settingsGetData.defaults.authMode,
+				signUpMode: settingsGetData.defaults.signUpMode,
+				extensions: settingsGetData.defaults.extensions,
+				extensionsMode: settingsGetData.defaults.extensionsMode,
+				storage: Number(storage[0]),
+				storageUnit: storage[1] as SettingsForm["storageUnit"],
+				uploadSize: Number(upload[0]),
+				uploadSizeUnit: upload[1] as SettingsForm["uploadSizeUnit"],
+				auditlog: Number(audit.filter((str) => !isNaN(Number(str))).reduce((a, b) => a + b, "")),
+				auditlogUnit: audit.filter((str) => isNaN(Number(str))).join("") as SettingsForm["auditlogUnit"]
+			});
+		}
+	}, [settingsGetData]);
+
+	const schema = object({
+		storage: number().required("Storage is a required option").min(0, "Storage cannot be below 0"),
+		storageUnit: string()
+			.required()
+			.oneOf(STORAGE_UNITS as unknown as string[]),
+		uploadSize: number().required("Upload size is a required option").min(0, "Upload size cannot be below 0"),
+		uploadSizeUnit: string()
+			.required()
+			.oneOf(STORAGE_UNITS as unknown as string[]),
+		extensions: array(string()).min(0).required(),
+		extensionsMode: string().required().oneOf(["block", "pass"]),
+		auditlog: number().required("Audit log Duration is a required option").min(0, "Audit log duration cannot be below 0"),
+		auditlogUnit: string()
+			.required()
+			.oneOf(TIME_UNITS_ARRAY as unknown as string[])
+	});
+
+	return (
+		<div className="max-w-[50vw] max-xl:max-w-[75vw] max-md:max-w-[100vw]">
+			<div>
+				<h1 className="text-3xl">Settings</h1>
+			</div>
+			<Formik validationSchema={schema} initialValues={initValues} onSubmit={onSubmit} validateOnMount enableReinitialize>
+				{(formik) => (
+					<Form>
+						<ul className="w-full mt-4 pr-2">
+							<li className="w-full mt-4">
+								<div className="mb-2">
+									<h2 className="text-lg">Default Max Storage</h2>
+									<p className="text-base">
+										This allows you to set the storage limit for PaperPlane accounts when they are created. Note: this does not
+										remove files from accounts if the limit is exceeded.
+									</p>
+								</div>
+								<div className="flex items-center gap-2 w-full">
+									<div className="w-3/4 max-sm:w-1/2">
+										<Input
+											type="tertiary"
+											formType="number"
+											inputMode="decimal"
+											placeholder="Storage amount, 0=infinitive"
+											className="w-full"
+											value={formik.values.storage}
+											onChange={(ctx) => formik.setFieldValue("storage", Number(ctx.currentTarget.value))}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.storage && `* ${formik.errors.storage}`}&#8203;
+										</p>
+									</div>
+									<div className="w-1/4 max-sm:w-1/2">
+										<SelectMenu
+											type="tertiary"
+											placeholder="Select a unit"
+											className="w-full"
+											options={STORAGE_UNITS.map((unit) => ({ value: unit, label: unit }))}
+											onChange={(value) => formik.setFieldValue("storageUnit", (value as SelectOption).value)}
+											value={{
+												label: formik.values.storageUnit,
+												value: formik.values.storageUnit
+											}}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.storageUnit && `* ${formik.errors.storageUnit}`}&#8203;
+										</p>
+									</div>
+								</div>
+							</li>
+							<li className="w-full mt-4">
+								<div className="mb-2">
+									<h2 className="text-lg">Default Max Upload Size</h2>
+									<p className="text-base">
+										This allows you to set the Upload Size for PaperPlane accounts when they are created. Note: if you use a
+										reverse-proxy like NGINX, make sure to configure an upload limit there too, otherwise this will not work.
+									</p>
+								</div>
+								<div className="flex items-center gap-2 w-full">
+									<div className="w-3/4 max-sm:w-1/2">
+										<Input
+											type="tertiary"
+											formType="number"
+											inputMode="decimal"
+											placeholder="Upload size amount, 0=infinitive"
+											className="w-full"
+											value={formik.values.uploadSize}
+											onChange={(ctx) => formik.setFieldValue("uploadSize", Number(ctx.currentTarget.value))}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.uploadSize && `* ${formik.errors.uploadSize}`}&#8203;
+										</p>
+									</div>
+									<div className="w-1/4 max-sm:w-1/2">
+										<SelectMenu
+											type="tertiary"
+											placeholder="Select a unit"
+											className="w-full"
+											options={STORAGE_UNITS.map((unit) => ({ value: unit, label: unit }))}
+											onChange={(value) => formik.setFieldValue("uploadSizeUnit", (value as SelectOption).value)}
+											value={{
+												label: formik.values.uploadSizeUnit,
+												value: formik.values.uploadSizeUnit
+											}}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.uploadSizeUnit && `* ${formik.errors.uploadSizeUnit}`}&#8203;
+										</p>
+									</div>
+								</div>
+							</li>
+							<li className="w-full mt-4">
+								<div className="mb-2">
+									<h2 className="text-lg">Default (Dis)Allowed Extensions</h2>
+									<p className="text-base">
+										This will allow you to accept/block the upload of certain file extensions (e.x. .png). Please use the
+										following format when using this: <strong>{".<extension>,.<extension>,...etc (e.x.: .png,.jpg)."}</strong>
+									</p>
+								</div>
+								<div className="flex items-center gap-2 w-full">
+									<div className="w-3/4 max-sm:w-1/2">
+										<Input
+											type="tertiary"
+											formType="text"
+											inputMode="text"
+											placeholder=".<extension>,...etc (e.x.: .png,.jpg)"
+											className="w-full"
+											value={formik.values.extensions.join(",")}
+											onChange={(ctx) => formik.setFieldValue("extensions", ctx.currentTarget.value.split(","))}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.extensions && `* ${formik.errors.extensions}`}&#8203;
+										</p>
+									</div>
+									<div className="w-1/4 max-sm:w-1/2">
+										<SelectMenu
+											type="tertiary"
+											placeholder="Select a mode"
+											className="w-full"
+											options={[
+												{ label: "Mode: block", value: "block" },
+												{ label: "Mode: pass", value: "pass" }
+											]}
+											onChange={(value) => formik.setFieldValue("extensionsMode", (value as SelectOption).value)}
+											value={{
+												label: `Mode: ${formik.values.extensionsMode}`,
+												value: formik.values.extensionsMode
+											}}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.extensionsMode && `* ${formik.errors.extensionsMode}`}&#8203;
+										</p>
+									</div>
+								</div>
+							</li>
+							<li className="w-full mt-4">
+								<div className="mb-2">
+									<h2 className="text-lg">Audit Log Duration</h2>
+									<p className="text-base">
+										This will determine the for how long the audit logs are visible. By default it is set to 1 month, you can use{" "}
+										<strong>0</strong> to set it to infinitive (not recommended).
+									</p>
+								</div>
+								<div className="flex items-center gap-2 w-full">
+									<div className="w-3/4 max-sm:w-1/2">
+										<Input
+											type="tertiary"
+											formType="number"
+											inputMode="decimal"
+											placeholder="Duration, 0=infinitive"
+											className="w-full"
+											value={formik.values.auditlog}
+											onChange={(ctx) => formik.setFieldValue("auditlog", Number(ctx.currentTarget.value))}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.auditlog && `* ${formik.errors.auditlog}`}&#8203;
+										</p>
+									</div>
+									<div className="w-1/4 max-sm:w-1/2">
+										<SelectMenu
+											type="tertiary"
+											placeholder="Select a unit"
+											className="w-full"
+											options={TIME_UNITS}
+											value={TIME_UNITS.find((unit) => unit.value === formik.values.auditlogUnit)}
+											onChange={(value) => formik.setFieldValue("auditlogUnit", (value as SelectOption).value)}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.auditlogUnit && `* ${formik.errors.auditlogUnit}`}&#8203;
+										</p>
+									</div>
+								</div>
+							</li>
+						</ul>
+						<PrimaryButton type="button" className="mt-4" disabled={formik.isSubmitting || !formik.isValid} onClick={formik.submitForm}>
+							{formik.isSubmitting ? <PulseLoader color="#fff" /> : <>Update Default Settings</>}
+						</PrimaryButton>
+					</Form>
+				)}
+			</Formik>
+		</div>
+	);
+};

--- a/packages/ui/src/admin/settings/SettingsForm.tsx
+++ b/packages/ui/src/admin/settings/SettingsForm.tsx
@@ -14,7 +14,7 @@ interface Props {
 	onSubmit: (...props: any) => void | Promise<void>;
 }
 
-interface SettingsForm {
+export interface SettingsForm {
 	authMode: "2fa" | "password";
 	signUpMode: "closed" | "open" | "invite";
 

--- a/packages/ui/src/admin/settings/SettingsForm.tsx
+++ b/packages/ui/src/admin/settings/SettingsForm.tsx
@@ -12,6 +12,7 @@ import { array, number, object, string } from "yup";
 
 interface Props {
 	onSubmit: (...props: any) => void | Promise<void>;
+	enableInviteModal: () => void;
 }
 
 export interface SettingsForm {
@@ -31,7 +32,7 @@ export interface SettingsForm {
 	auditlogUnit: (typeof TIME_UNITS_ARRAY)[number];
 }
 
-export const AdminSettingsForm: React.FC<Props> = ({ onSubmit }) => {
+export const AdminSettingsForm: React.FC<Props> = ({ onSubmit, enableInviteModal }) => {
 	const [initValues, setInitValues] = useState<SettingsForm>({
 		authMode: "2fa",
 		signUpMode: "closed",
@@ -161,7 +162,9 @@ export const AdminSettingsForm: React.FC<Props> = ({ onSubmit }) => {
 										</p>
 									</div>
 									<div>
-										<PrimaryButton type="button">Open list of Invite Codes</PrimaryButton>
+										<PrimaryButton type="button" onClick={enableInviteModal}>
+											Open list of Invite Codes
+										</PrimaryButton>
 										<p className="text-red text-left text-small font-normal">&#8203;</p>
 									</div>
 								</div>

--- a/packages/ui/src/admin/settings/SettingsForm.tsx
+++ b/packages/ui/src/admin/settings/SettingsForm.tsx
@@ -41,8 +41,8 @@ export const AdminSettingsForm: React.FC<Props> = ({ onSubmit }) => {
 		uploadSizeUnit: "GB",
 		extensions: [],
 		extensionsMode: "block",
-		auditlog: 1,
-		auditlogUnit: "mth"
+		auditlog: 31,
+		auditlogUnit: "d"
 	});
 	const { data: settingsGetData } = useSwr<SettingsGetApi>("/api/admin/settings", undefined, (url) =>
 		axios.get(url, { withCredentials: true }).then((res) => res.data)

--- a/packages/ui/src/admin/settings/SettingsForm.tsx
+++ b/packages/ui/src/admin/settings/SettingsForm.tsx
@@ -109,6 +109,11 @@ export const AdminSettingsForm: React.FC<Props> = ({ onSubmit }) => {
 										authentication.
 									</p>
 								</div>
+								<div className="bg-red p-2 rounded-xl my-4">
+									⚠️ <strong>Warning</strong>: changing this may have unintended side-effects. This could also lead to accounts
+									being compromised if not handled correctly.All accounts will start with the default password or back-up code:
+									<span className="bg-main p-1 rounded-xl ml-1">paperplane-cdn</span> if they one or both are unset.
+								</div>
 								<div className="flex items-center gap-2 w-full">
 									<div className="w-full">
 										<SelectMenu

--- a/packages/ui/src/admin/settings/SettingsForm.tsx
+++ b/packages/ui/src/admin/settings/SettingsForm.tsx
@@ -102,6 +102,67 @@ export const AdminSettingsForm: React.FC<Props> = ({ onSubmit }) => {
 						<ul className="w-full mt-4 pr-2">
 							<li className="w-full mt-4">
 								<div className="mb-2">
+									<h2 className="text-lg">Authentication Mode</h2>
+									<p className="text-base">
+										Change the way people login to PaperPlane, this does not affect the{" "}
+										<span className="bg-primary p-1 rounded-xl">Admin Panel</span> login strategy. This will always be a 2FA based
+										authentication.
+									</p>
+								</div>
+								<div className="flex items-center gap-2 w-full">
+									<div className="w-full">
+										<SelectMenu
+											type="tertiary"
+											placeholder="Select a mode"
+											className="w-full"
+											options={["2fa", "password"].map((type) => ({ label: `Mode: ${type}`, value: type }))}
+											onChange={(value) => formik.setFieldValue("authMode", (value as SelectOption).value)}
+											value={{
+												label: `Mode: ${formik.values.authMode}`,
+												value: formik.values.authMode
+											}}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.authMode && `* ${formik.errors.authMode}`}&#8203;
+										</p>
+									</div>
+								</div>
+							</li>
+							<li className="w-full mt-4">
+								<div className="mb-2">
+									<h2 className="text-lg">Sign Up</h2>
+									<p className="text-base">
+										Changes the way sign ups are handled. If set to <strong>closed</strong> the signup page is disabled (default).{" "}
+										<strong>Open</strong> means the page is open and everyone can create an account (not recommended),{" "}
+										<strong>invite</strong> will allow you to generate and hand out invite codes which are then required to sign
+										up. These tokens are only usable once.
+									</p>
+								</div>
+								<div className="flex items-center justify-between w-full max-sm:flex-col max-sm:items-start">
+									<div className="w-1/4 max-sm:w-1/2">
+										<SelectMenu
+											type="tertiary"
+											placeholder="Select a mode"
+											className="w-full"
+											options={["closed", "open", "invite"].map((type) => ({ label: `Mode: ${type}`, value: type }))}
+											onChange={(value) => formik.setFieldValue("signUpMode", (value as SelectOption).value)}
+											value={{
+												label: `Mode: ${formik.values.signUpMode}`,
+												value: formik.values.signUpMode
+											}}
+										/>
+										<p className="text-red text-left text-small font-normal">
+											{formik.errors.signUpMode && `* ${formik.errors.signUpMode}`}&#8203;
+										</p>
+									</div>
+									<div>
+										<PrimaryButton type="button">Open list of Invite Codes</PrimaryButton>
+										<p className="text-red text-left text-small font-normal">&#8203;</p>
+									</div>
+								</div>
+							</li>
+							<li className="w-full mt-4">
+								<div className="mb-2">
 									<h2 className="text-lg">Default Max Storage</h2>
 									<p className="text-base">
 										This allows you to set the storage limit for PaperPlane accounts when they are created. Note: this does not

--- a/packages/ui/src/admin/settings/index.ts
+++ b/packages/ui/src/admin/settings/index.ts
@@ -1,0 +1,1 @@
+export * from "./SettingsForm";

--- a/packages/ui/src/admin/settings/index.ts
+++ b/packages/ui/src/admin/settings/index.ts
@@ -1,3 +1,5 @@
 export * from "./SettingsForm";
 export * from "./InvitesModal";
 export * from "./Domains";
+export * from "./Backups";
+export * from "./ResetButtons";

--- a/packages/ui/src/admin/settings/index.ts
+++ b/packages/ui/src/admin/settings/index.ts
@@ -1,1 +1,2 @@
 export * from "./SettingsForm";
+export * from "./InvitesModal";

--- a/packages/ui/src/admin/settings/index.ts
+++ b/packages/ui/src/admin/settings/index.ts
@@ -1,2 +1,3 @@
 export * from "./SettingsForm";
 export * from "./InvitesModal";
+export * from "./Domains";

--- a/packages/utils/src/Admin.ts
+++ b/packages/utils/src/Admin.ts
@@ -76,6 +76,24 @@ export interface CreateGetApi {
 	};
 }
 
+export interface SettingsGetApi {
+	domains: SignUpDomain[];
+	defaults: {
+		authMode: "2fa" | "password";
+		signUpMode: "closed" | "open" | "invite";
+		extensions: string[];
+		extensionsMode: "block" | "pass";
+		maxStorage: number;
+		maxUploadSize: number;
+		auditlog: number;
+	};
+}
+
+export interface SignUpDomain {
+	domain: string;
+	date: Date;
+}
+
 export const TIME_UNITS = [
 	{ label: "Seconds", value: "s" },
 	{ label: "Minutes", value: "m" },

--- a/packages/utils/src/Admin.ts
+++ b/packages/utils/src/Admin.ts
@@ -99,8 +99,7 @@ export const TIME_UNITS = [
 	{ label: "Minutes", value: "m" },
 	{ label: "Days", value: "d" },
 	{ label: "Weeks", value: "w" },
-	{ label: "Months", value: "mth" },
 	{ label: "Years", value: "y" }
 ] as const;
 
-export const TIME_UNITS_ARRAY = ["s", "m", "d", "w", "mth", "y"] as const;
+export const TIME_UNITS_ARRAY = ["s", "m", "d", "w", "y"] as const;

--- a/packages/utils/src/Admin.ts
+++ b/packages/utils/src/Admin.ts
@@ -104,6 +104,16 @@ export interface Invite {
 	date: Date;
 }
 
+export interface SignUpDomainGetApi {
+	entries: SignUpDomain[];
+	pages: number;
+}
+
+export interface SignUpDomain {
+	domain: string;
+	date: Date;
+}
+
 export const TIME_UNITS = [
 	{ label: "Seconds", value: "s" },
 	{ label: "Minutes", value: "m" },

--- a/packages/utils/src/Admin.ts
+++ b/packages/utils/src/Admin.ts
@@ -94,6 +94,16 @@ export interface SignUpDomain {
 	date: Date;
 }
 
+export interface InviteGetApi {
+	entries: Invite[];
+	pages: number;
+}
+
+export interface Invite {
+	invite: string;
+	date: Date;
+}
+
 export const TIME_UNITS = [
 	{ label: "Seconds", value: "s" },
 	{ label: "Minutes", value: "m" },

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -49,23 +49,6 @@ export const getProtocol = () => {
 };
 
 export const parseToDay = (amount: number, unit: (typeof TIME_UNITS_ARRAY)[number]) => {
-	switch (unit) {
-		case "w":
-			unit = "d";
-			amount *= 7;
-			break;
-		case "mth":
-			unit = "d";
-			amount *= 31;
-			break;
-		case "y":
-			unit = "d";
-			amount *= 365;
-			break;
-		default:
-			break;
-	}
-
 	return `${amount}${unit}`;
 };
 


### PR DESCRIPTION
### Please describe the changes this PR makes:
- Adds settings page
- Adds Invite Modal
- Adds Domains Modal
- Adds various APIs

**DOES NOT ADD THE FOLLOWING:**
- Backup creation and selection
- *Reset buttons

<!--
### Linked Issues:
Mention an issue here (example: #1)
-->

---

### To do list:
- [x] remove `mth` time unit option
- [x] fix defaultValue issue with SelectMenu's
- [x] Domains Modal
- [x] Domains Section
- [x] Big Red Buttons
- [x] Backups
- [x] Invites Modal
- [x] Add Audit Logging: Invites, Domains
